### PR TITLE
Used setRefresh to update plant list for garden for PDF print

### DIFF
--- a/ui/src/pages/GardenDetails.jsx
+++ b/ui/src/pages/GardenDetails.jsx
@@ -18,6 +18,7 @@ function GardenDetails() {
   const [garden, setGarden] = useState(null);
   const [editMode, setEditMode] = useState(false);
   const [newName, setNewName] = useState("");
+  const [refresh, setRefresh] = useState("");
   const navigate = useNavigate();
   const token = localStorage.getItem("JWT_TOKEN");
   const csrfToken = localStorage.getItem("CSRF_TOKEN");
@@ -58,8 +59,10 @@ function GardenDetails() {
       .then((data) => {
         setGarden(data);
         setNewName(data.name);
-      });
-  }, [gardenId]);
+      })
+      .catch((err) => console.error("Error fetching garden details:", err));
+  }, [gardenId, refresh]);
+
 
   const handleNameSave = () => {
     const confirm = window.confirm(
@@ -378,7 +381,7 @@ function GardenDetails() {
             {garden.plants && garden.plants.length > 0 ? (
               <div className="plant-list">
                 {garden.plants.map((plant) => (
-                  <PlantCard key={plant.id} plant={plant} gardenId={gardenId} />
+                  <PlantCard key={plant.id} plant={plant} gardenId={gardenId} setRefresh={setRefresh} />
                 ))}
               </div>
             ) : (

--- a/ui/src/reusable-code/PlantCard.jsx
+++ b/ui/src/reusable-code/PlantCard.jsx
@@ -3,7 +3,7 @@ import "../custom-css/PlantCard.css";
 import { Link } from "react-router-dom";
 
 //get plant and gardenId from PlantSearch and pass as props
-function PlantCard({ plant, gardenId }) {
+function PlantCard({ plant, gardenId, setRefresh }) {
   const [inGarden, setInGarden] = useState(false);
   const plantId = plant.id;
 
@@ -63,6 +63,9 @@ function PlantCard({ plant, gardenId }) {
       const dtoData = await response.json();
       if (response.ok) {
         setInGarden(dtoData.plantInGarden);
+        if (setRefresh) {
+          setRefresh(prev => !prev);
+        }
       }
     } catch (error) {
       console.error("Error adding plant:", error);
@@ -94,6 +97,9 @@ function PlantCard({ plant, gardenId }) {
       const dtoData = await response.json();
       if (response.ok) {
         setInGarden(dtoData.plantInGarden);
+        if (setRefresh) {
+          setRefresh(prev => !prev);
+        }
       }
     } catch (error) {
       console.error("Error removing plant:", error);


### PR DESCRIPTION
I do not know if we want to merge this or not.  What this code does is immediately remove a plant from the garden details page once the user clicks "remove".  Allyson's intention was for it to stay on the page just in case the user accidentally hit "delete".  I agree with this.  However, I am running out of time to fix it.  

If we don't merge this, the plant stays on the garden details page, and it does update the garden by removing the plant, but it does NOT update the PDF unless you refresh the entire page.